### PR TITLE
fix: Change Feickert term end to 2028

### DIFF
--- a/members.html
+++ b/members.html
@@ -173,7 +173,7 @@
       { name: "Peter Boyle", institution: "Brookhaven National Laboratory", term: "2025-2026" },
       { name: "Gavin S. Davies", institution: "University of Mississippi", term: "2025-2027" },
       { name: "Victor Daniel Elvira", institution: "Fermi National Accelerator Laboratory", term: "2025-2026" },
-      { name: "Matthew Feickert", institution: "University of Wisconsin-Madison Data Science Institute", term: "2025-2026" },
+      { name: "Matthew Feickert", institution: "University of Wisconsin-Madison Data Science Institute", term: "2025-2028" },
       { name: "Ian Fisk (CPSC Chair)", institution: "Flatiron Institute, Simons Foundation", term: "2025-2028" },
       { name: "Sam Foreman", institution: "Argonne National Laboratory", term: "2025-2026" },
       { name: "Leslie Groer", institution: "University of Toronto", term: "2025-2027" },


### PR DESCRIPTION
I was checking the website today and noticed a typo in my term ([should end in 2028](https://higherlogicdownload.s3.amazonaws.com/APS/8130f693-9c12-43e9-9311-1246dda64a3e/UploadedImages/2025-04-DPF-Newsletter.pdf)).